### PR TITLE
[swagger] swagger default URL 수정

### DIFF
--- a/back/demo/src/main/java/OOTD/demo/DemoApplication.java
+++ b/back/demo/src/main/java/OOTD/demo/DemoApplication.java
@@ -1,8 +1,10 @@
 package OOTD.demo;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "OOTD API Server URL")})
 @SpringBootApplication
 public class DemoApplication {
 


### PR DESCRIPTION
## 개요
1. swagger default URL을 http에서 https로 수정

## 변경 사항

## 확인 방법 (스크린샷 첨부 가능)

## 한계점 / 문제점
