### PR TITLE
[back-end] 팔로우 및 게시글 페이징 로직 완성

### DIFF
--- a/back/demo/build.gradle
+++ b/back/demo/build.gradle
@@ -1,6 +1,13 @@
+buildscript {
+	ext {
+		queryDslVersion = '5.0.0'
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.5'
+	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
@@ -72,10 +79,31 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
 	implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.12'
+
+	// data_access
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// -- QueryDsl Setting -------------------------------------------------------
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }
 
 // plain 파일 생성하지 않는 설정

--- a/back/demo/src/main/java/OOTD/demo/config/QueryDslConfig.java
+++ b/back/demo/src/main/java/OOTD/demo/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package OOTD.demo.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/back/demo/src/main/java/OOTD/demo/diary/controller/DiaryController.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/controller/DiaryController.java
@@ -28,6 +28,7 @@ import java.util.List;
  */
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/diary")
 @Slf4j
 public class DiaryController {
 
@@ -50,7 +51,7 @@ public class DiaryController {
             @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR - 내부 서버 오류",
                     content = @Content)
     })
-    @PostMapping("/api/diary/create")
+    @PostMapping
     public ResponseEntity<?> createDiary(
             @Parameter(name = "dto", description = "게시글 생성 관련 DTO") @RequestPart @Valid PostDiaryReq dto,
             @Parameter(name = "files", description = "게시글 사진들") @RequestPart List<MultipartFile> files) {
@@ -60,14 +61,28 @@ public class DiaryController {
     }
 
     /**
+     * 게시글 리스트를 조회하는 컨트롤러 메서드입니다.
+     * @param isExistFollowerDiary 팔로워의 게시글을 조회할 것인지
+     * @param lastId 마지막으로 반환된 결과 중 가장 마지막 게시글의 id
+     * @return 페이징된 게시글 리스트
+     */
+    @GetMapping
+    public ResponseEntity<?> getDiaryList(@RequestParam boolean isExistFollowerDiary, @RequestParam int lastId) {
+
+        return httpResponseUtil.createOkHttpResponse(diaryService.findDiaryList(isExistFollowerDiary, lastId),
+                "게시글 리스트 조회에 성공했습니다.");
+
+    }
+
+    /**
      * 단일 게시글을 조회하는 컨트롤러 메서드입니다.
      * @param id 게시글 ID
      * @return 해당 게시글의 정보를 담고 있는 DTO
      */
     @Operation(summary = "게시글 조회 API", description = "게시글 조회 API입니다.",
             tags = { "Diary Controller" })
-    @GetMapping("/api/diary/{id}")
-    public ResponseEntity<?> findDiary(@PathVariable(name = "id") Long id) {
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getSingleDiary(@PathVariable(name = "id") Long id) {
 
         // TODO : 공개 여부에 따라 퍼미션 거부 로직 필요
 
@@ -81,7 +96,7 @@ public class DiaryController {
      */
     @Operation(summary = "게시글 수정 API", description = "게시글 수정 API입니다. (TODO : 현재 User가 NULL로 들어갑니다.)",
             tags = { "Diary Controller" })
-    @PostMapping("/api/diary/update")
+    @PutMapping
     public ResponseEntity<?> updateDiary(@RequestPart UpdateDiaryReq dto, @RequestPart List<MultipartFile> files) {
 
         return httpResponseUtil.createOkHttpResponse(diaryService.updatePost(dto, files), "게시글 수정에 성공했습니다.");
@@ -94,7 +109,7 @@ public class DiaryController {
      */
     @Operation(summary = "게시글 삭제 API", description = "게시글 삭제 API입니다.",
             tags = { "Diary Controller" })
-    @GetMapping("/api/diary/delete/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteDiary(@PathVariable(name = "id") Long id) {
 
         diaryService.deleteDiary(id);

--- a/back/demo/src/main/java/OOTD/demo/diary/dto/DiaryDto.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/dto/DiaryDto.java
@@ -1,5 +1,6 @@
 package OOTD.demo.diary.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,6 @@ import java.time.LocalDateTime;
  * @author CHO Min HO
  */
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class DiaryDto {
     private Long id;
@@ -21,4 +21,15 @@ public class DiaryDto {
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
     private Long userId;
+
+    @QueryProjection
+    public DiaryDto(Long id, String title, String content, LocalDateTime createDate, LocalDateTime updateDate, Long userId) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
+        this.userId = userId;
+    }
+
 }

--- a/back/demo/src/main/java/OOTD/demo/diary/dto/DiaryListRes.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/dto/DiaryListRes.java
@@ -1,0 +1,22 @@
+package OOTD.demo.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 게시글 리스트를 조회할 때 사용하는 response 객체입니다.
+ *
+ * @author CHO Min Ho
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DiaryListRes {
+
+    List<DiaryDto> diaryList;
+    boolean isLastDiaryFollowers;
+
+}

--- a/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepository.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepository.java
@@ -1,0 +1,13 @@
+package OOTD.demo.diary.repository;
+
+import OOTD.demo.diary.dto.DiaryDto;
+import OOTD.demo.user.User;
+
+import java.util.List;
+
+public interface DiaryQueryRepository {
+
+    List<DiaryDto> findFollowersDiaryByUser(User user, int lastId);
+    List<DiaryDto> findDiaryByDate(int lastId, int number);
+
+}

--- a/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepositoryImpl.java
@@ -1,0 +1,43 @@
+package OOTD.demo.diary.repository;
+
+import OOTD.demo.diary.dto.DiaryDto;
+import OOTD.demo.diary.dto.QDiaryDto;
+import OOTD.demo.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+import static OOTD.demo.diary.QDiary.diary;
+import static OOTD.demo.follow.QFollow.follow;
+
+@RequiredArgsConstructor
+public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final int ONCE_PAGING_NUMBER = 20;
+
+    @Override
+    public List<DiaryDto> findFollowersDiaryByUser(User user, int lastId) {
+        return queryFactory
+                .select(new QDiaryDto(diary.id, diary.title, diary.content, diary.createDate, diary.updateDate, diary.user.id))
+                .from(diary)
+                .join(follow)
+                .on(diary.user.id.eq(follow.follower.id).and(follow.followee.id.eq(user.getId())))
+                .fetchJoin()
+                .where(diary.id.gt(lastId))
+                .orderBy(diary.id.asc())
+                .limit(ONCE_PAGING_NUMBER)
+                .fetch();
+    }
+
+    @Override
+    public List<DiaryDto> findDiaryByDate(int lastId, int number) {
+        return queryFactory
+                .select(new QDiaryDto(diary.id, diary.title, diary.content, diary.createDate, diary.updateDate, diary.user.id))
+                .from(diary)
+                .where(diary.id.gt(lastId))
+                .orderBy(diary.id.asc())
+                .limit(number)
+                .fetch();
+    }
+}

--- a/back/demo/src/main/java/OOTD/demo/follow/Follow.java
+++ b/back/demo/src/main/java/OOTD/demo/follow/Follow.java
@@ -1,0 +1,42 @@
+package OOTD.demo.follow;
+
+import OOTD.demo.user.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    private User follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "followee_id")
+    private User followee;
+
+    private Follow(User follower, User followee) {
+        this.follower = follower;
+        this.followee = followee;
+    }
+
+    /**
+     * Follow 엔티티를 생성하는 메서드입니다.
+     * @param follower 팔로워 (팔로우를 하는 사람)
+     * @param followee 팔로우를 받는 사람
+     * @return 생성된 Follow 엔티티
+     */
+    public static Follow createFollow(User follower, User followee) {
+        return new Follow(follower, followee);
+    }
+}

--- a/back/demo/src/main/java/OOTD/demo/follow/controller/FollowController.java
+++ b/back/demo/src/main/java/OOTD/demo/follow/controller/FollowController.java
@@ -1,0 +1,39 @@
+package OOTD.demo.follow.controller;
+
+import OOTD.demo.common.HttpResponseUtil;
+import OOTD.demo.follow.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 팔로우 관계 관련 컨트롤러입니다.
+ *
+ * @author CHO Min Ho
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/follow")
+@Slf4j
+public class FollowController {
+
+    private final FollowService followService;
+    private final HttpResponseUtil httpResponseUtil;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> createFollower(@PathVariable Long id) {
+
+        return httpResponseUtil.createOkHttpResponse(followService.createFollower(id), "팔로우에 성공했습니다.");
+
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteFollower(@PathVariable Long id) {
+
+        followService.deleteFollower(id);
+
+        return httpResponseUtil.createOkHttpResponse(null, "팔로우 취소에 성공했습니다.");
+
+    }
+}

--- a/back/demo/src/main/java/OOTD/demo/follow/repository/FollowRepository.java
+++ b/back/demo/src/main/java/OOTD/demo/follow/repository/FollowRepository.java
@@ -1,0 +1,16 @@
+package OOTD.demo.follow.repository;
+
+import OOTD.demo.follow.Follow;
+import OOTD.demo.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Follow JPA repository 입니다.
+ *
+ * @author CHO Min Ho
+ */
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    void deleteByFollower(User user);
+
+}

--- a/back/demo/src/main/java/OOTD/demo/follow/service/FollowService.java
+++ b/back/demo/src/main/java/OOTD/demo/follow/service/FollowService.java
@@ -1,0 +1,46 @@
+package OOTD.demo.follow.service;
+
+import OOTD.demo.auth.service.AuthService;
+import OOTD.demo.follow.Follow;
+import OOTD.demo.follow.repository.FollowRepository;
+import OOTD.demo.user.User;
+import OOTD.demo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final AuthService authService;
+    private final UserRepository userRepository;
+
+    /**
+     * 팔로우 관계를 생성하는 메서드입니다.
+     * @param id 팔로우할 대상의 user id
+     * @return 생성된 팔로우 엔티티의 id
+     */
+    public Long createFollower(Long id) {
+
+        User currentLoginUser = authService.getCurrentLoginUser();
+
+        return followRepository.save(Follow.createFollow(currentLoginUser,
+                userRepository.findById(id).orElseThrow(IllegalArgumentException::new))).getId();
+    }
+
+    /**
+     * 팔로우 관계를 삭제하는 메서드입니다.
+     * @param id 대상 팔로워의 user id
+     */
+    public void deleteFollower(Long id) {
+
+        followRepository.deleteByFollower(userRepository.findById(id).orElseThrow(IllegalArgumentException::new));
+
+    }
+
+}


### PR DESCRIPTION
## 개요
전체 게시글 페이지에서 무한 스크롤을 이용한 게시글 조회가 되도록 로직 완성

## 변경 사항
1. 팔로우 엔티티 및 로직 추가
2. 팔로우 관계를 이용해서 게시글을 일정 개수만큼 페이징해오는 로직 추가
3. 팔로우 관련 API 및 게시글 리스트 조회 API 추가

## 확인 방법 (스크린샷 첨부 가능)

## 한계점 / 문제점
