### PR TITLE
[back-end] refresh token 도입

### DIFF
--- a/back/demo/src/main/java/OOTD/demo/DemoApplication.java
+++ b/back/demo/src/main/java/OOTD/demo/DemoApplication.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @OpenAPIDefinition(servers = {@Server(url = "/", description = "OOTD API Server URL")})
 @EnableJpaAuditing
 @SpringBootApplication

--- a/back/demo/src/main/java/OOTD/demo/auth/RefreshToken.java
+++ b/back/demo/src/main/java/OOTD/demo/auth/RefreshToken.java
@@ -1,0 +1,52 @@
+package OOTD.demo.auth;
+
+import OOTD.demo.user.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "token_id")
+    private Long id;
+
+    @Column(name = "token_value")
+    private String refreshToken;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "valid_until")
+    private LocalDateTime expirationPeriod;
+
+    private RefreshToken(String refreshToken, User user, LocalDateTime expirationPeriod) {
+        this.refreshToken = refreshToken;
+        this.user = user;
+        this.expirationPeriod = expirationPeriod;
+    }
+
+    /**
+     * Refresh Token 을 생성하는 메서드입니다.
+     * @param user 사용자
+     * @param expirationPeriod 유효기간
+     * @return 생성된 RefreshToken 객체
+     */
+    public static RefreshToken createRefreshToken(User user, LocalDateTime expirationPeriod) {
+        return new RefreshToken(UUID.randomUUID().toString().substring(0, 20), user, expirationPeriod);
+    }
+
+    public void extendExpirationPeriod(LocalDateTime expirationPeriod) {
+        this.expirationPeriod = expirationPeriod;
+    }
+
+}

--- a/back/demo/src/main/java/OOTD/demo/auth/controller/AuthController.java
+++ b/back/demo/src/main/java/OOTD/demo/auth/controller/AuthController.java
@@ -5,15 +5,19 @@ import OOTD.demo.common.HttpResponseUtil;
 import OOTD.demo.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
 
 @RestController
@@ -58,11 +62,26 @@ public class AuthController {
     @Operation(summary = "로그아웃 API", description = "로그아웃 API 입니다.",
             tags = { "Auth Controller" })
     @PostMapping("/api/auth/logout")
-    public ResponseEntity<?> logout(HttpSession session){
+    public ResponseEntity<?> logout(HttpServletRequest request){
 
-        authService.logout(session);
+        authService.logout(request);
         return httpResponseUtil.createOkHttpResponse(null, "로그아웃에 성공했습니다.");
 
+    }
+
+    @Operation(summary = "Access Token 재발급 API", description = "Access Token 재발급 API 입니다.",
+            tags = { "Auth Controller" })
+    @GetMapping("/api/auth/token/reissuance")
+    public ResponseEntity<?> reissueRefreshToken(HttpServletRequest request) {
+
+        AccessTokenRes accessTokenRes = authService.reissueAccessToken(request);
+
+        if (accessTokenRes == null) {
+            return httpResponseUtil.createErrorResponse(null, "refreshToken이 만료되었습니다.",
+                    FORBIDDEN);
+        }
+
+        return httpResponseUtil.createOkHttpResponse(authService, "access token 재발급에 성공했습니다.");
     }
 
 }

--- a/back/demo/src/main/java/OOTD/demo/auth/dto/AccessTokenRes.java
+++ b/back/demo/src/main/java/OOTD/demo/auth/dto/AccessTokenRes.java
@@ -1,0 +1,13 @@
+package OOTD.demo.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessTokenRes {
+
+    private String accessToken;
+}

--- a/back/demo/src/main/java/OOTD/demo/auth/dto/LoginRes.java
+++ b/back/demo/src/main/java/OOTD/demo/auth/dto/LoginRes.java
@@ -17,5 +17,7 @@ public class LoginRes {
 
     Long memberId;
 
-    String userAuthenticationId;
+    String accessToken;
+
+    String refreshToken;
 }

--- a/back/demo/src/main/java/OOTD/demo/auth/filter/JwtFilter.java
+++ b/back/demo/src/main/java/OOTD/demo/auth/filter/JwtFilter.java
@@ -1,6 +1,7 @@
 package OOTD.demo.auth.filter;
 
 import OOTD.demo.auth.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,15 +16,11 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
 @Slf4j
+@RequiredArgsConstructor
 public class JwtFilter extends GenericFilterBean {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
-
     private final TokenProvider tokenProvider;
-
-    public JwtFilter(TokenProvider tokenProvider){
-        this.tokenProvider = tokenProvider;
-    }
 
     // 실제 필터링 로직 작성
     // doFilter : 토큰의 인증 정보를 SecurityContext에 저장
@@ -33,29 +30,35 @@ public class JwtFilter extends GenericFilterBean {
 
         // resolveToken을 통해 토큰을 받아옴
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        String jwt = resolveToken(httpServletRequest);
+        String accessToken = resolveAccessToken(httpServletRequest);
         String requestURI = httpServletRequest.getRequestURI();
 
         // 토큰 유효성 검증 후 정상이면 SecurityContext에 저장
-        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-            Authentication authentication = tokenProvider.getAuthentication(jwt);
+        if (StringUtils.hasText(accessToken) && tokenProvider.validateToken(accessToken)) {
+
+            Authentication authentication = tokenProvider.getAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
-        } else log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+        }
 
         // 생성한 필터 실행
         chain.doFilter(httpServletRequest, response);
     }
 
     // Request Header에서 토큰 정보를 꺼내오기
-    private String resolveToken(HttpServletRequest request) {
+    private String resolveAccessToken(HttpServletRequest request) {
+
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
 
-            System.out.println("token : " + bearerToken);
+            log.info("token : {}", bearerToken);
 
             return bearerToken.substring(7);
         }
         return null;
     }
+
 }

--- a/back/demo/src/main/java/OOTD/demo/auth/repository/RefreshTokenRepository.java
+++ b/back/demo/src/main/java/OOTD/demo/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package OOTD.demo.auth.repository;
+
+import OOTD.demo.auth.RefreshToken;
+import OOTD.demo.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+    void deleteByRefreshToken(String refreshToken);
+    void deleteAllByExpirationPeriodBefore(LocalDateTime currentTime);
+
+}

--- a/back/demo/src/main/java/OOTD/demo/common/HttpResponseUtil.java
+++ b/back/demo/src/main/java/OOTD/demo/common/HttpResponseUtil.java
@@ -2,10 +2,12 @@ package OOTD.demo.common;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 /**
  * 컨트롤러에서 반환하는 공통 양식을 생성하는 Util 클래스입니다.
@@ -26,7 +28,9 @@ public class HttpResponseUtil {
         message.setStatus(Message.StatusEnum.OK);
         message.setMessage(responseMessage);
         message.setData(object);
-        return new ResponseEntity<>(message, new HttpHeaders(), OK);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(APPLICATION_JSON);
+        return new ResponseEntity<>(message, httpHeaders, OK);
     }
 
     /**
@@ -41,6 +45,8 @@ public class HttpResponseUtil {
         message.setStatus(Message.StatusEnum.from(status));
         message.setMessage(responseMessage);
         message.setData(object);
-        return new ResponseEntity<>(message, new HttpHeaders(), status);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(APPLICATION_JSON);
+        return new ResponseEntity<>(message, httpHeaders, status);
     }
 }

--- a/back/demo/src/main/java/OOTD/demo/config/SecurityConfig.java
+++ b/back/demo/src/main/java/OOTD/demo/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                 .antMatchers("/api/auth/create").permitAll()
                 .antMatchers("/api/auth/login").permitAll()
                 .antMatchers("/api/auth/checkname").permitAll()
+                .antMatchers("/api/auth/token/reissuance").permitAll()
                 .antMatchers("/test/**").permitAll()
 
                 // swagger 관련 처리

--- a/back/demo/src/main/resources/application-dev.yml
+++ b/back/demo/src/main/resources/application-dev.yml
@@ -39,7 +39,8 @@ logging:
 jwt:
   header: Authorization
   secret: testSecretKey12345testSecretKey12345testSecretKey12345testSecretKey12345testSecretKey12345testSecretKey12345
-  token-validity-in-seconds: 86400
+  token-validity-in-seconds: 1800
+  refresh-token-validity-in-seconds: 2592000
 
 # Swagger
 springdoc:

--- a/back/demo/src/main/resources/application-prod.yml
+++ b/back/demo/src/main/resources/application-prod.yml
@@ -61,6 +61,7 @@ jwt:
   header: Authorization
   secret: ${jwt.secret.key}
   token-validity-in-seconds: ${jwt.token.validity.in.seconds}
+  refresh-token-validity-in-seconds: ${jwt.refresh.token.validity.in.seconds}
 
 # Swagger
 springdoc:

--- a/back/demo/src/test/resources/application-dev.yml
+++ b/back/demo/src/test/resources/application-dev.yml
@@ -32,7 +32,8 @@ spring:
 jwt:
   header: Authorization
   secret: testSecretKey12345testSecretKey12345testSecretKey12345testSecretKey12345testSecretKey12345testSecretKey12345
-  token-validity-in-seconds: 86400
+  token-validity-in-seconds: 1800
+  refresh-token-validity-in-seconds: 2592000
 
 # Logging
 logging:

--- a/back/demo/src/test/resources/application-prod.yml
+++ b/back/demo/src/test/resources/application-prod.yml
@@ -61,6 +61,7 @@ jwt:
   header: Authorization
   secret: ${jwt.secret.key}
   token-validity-in-seconds: ${jwt.token-validity-in-seconds}
+  refresh-token-validity-in-seconds: ${jwt.refresh.token.validity.in.seconds}
 
 # Swagger
 springdoc:


### PR DESCRIPTION
## 개요
refresh token 도입을 통한 로그인 로직 보완, 로그아웃 구현

## 변경 사항
1. 로그인 시 access token, refresh token을 발급
2. access token 만료 시, refresh token을 포함해서 token 재발급 api로 요청 시, access token 재발급
3. 스케줄러를 통해 주기적으로 만료된 refresh token을 삭제

## 확인 방법 (스크린샷 첨부 가능)

## 한계점 / 문제점
추후 Redis 등 인메모리 DB로 refresh token 관리 필요