### PR TITLE
Front end merge pull request

### DIFF
--- a/front/src/input/LoginInput.js
+++ b/front/src/input/LoginInput.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { TextInput, StyleSheet } from "react-native";
+import { TextInput, StyleSheet, Platform} from "react-native";
 
 export default function InputText({
   placeHoldText,
@@ -36,5 +36,13 @@ const styles = StyleSheet.create({
     padding: 10,
     margin: 10,
     fontSize: 13,
+    ...Platform.select({
+      ios: {
+        elevation : 5,
+      },
+      android: {
+        elevation : 5,
+      }
+    })
   },
 });

--- a/front/src/profile/EditMyProfileView.js
+++ b/front/src/profile/EditMyProfileView.js
@@ -1,9 +1,63 @@
-import { Text, StyleSheet, View, Alert, FlatList, Image, Pressable,} from "react-native";
+import { 
+  Text, 
+  StyleSheet, 
+  View, 
+  Alert, 
+  FlatList, 
+  Image, 
+  Pressable, 
+  NativeModules,} from "react-native";
+import { useState, useEffect } from "react";
 import CameraImg from "../../assets/images/circlecamera.png";
+import InfoInput from "../joinMembership/InfoInput";
+import Btn from "../button/Btn";
 
-export default function EditMyProfileView (handleEmailChange) {
+const { StatusBarManager } = NativeModules;
+
+export default function EditMyProfileView ({navigation}) {
   const ImgClick = () => {
     Alert.alert('이미지 추가 버튼','이미지 추가 버튼임');
+  };
+
+
+  const [checkEssentialFill, setCheckEssentialFill] = useState(false);
+  const handleCheckEssentialFill = (isFill) => {
+    isFill ? setCheckEssentialFill(true) : setCheckEssentialFill(false);
+  };
+
+  useEffect(() => {
+    Platform.OS == "ios"
+      ? StatusBarManager.getHeight((statusBarFrameData) => {
+          setStatusBarHeight(statusBarFrameData.height);
+        })
+      : null;
+  }, []);
+
+  const [statusBarHeight, setStatusBarHeight] = useState(0);
+
+  const [accountChange, setAccountChange] = useState("");
+  const handleAccountChange = (text) => {
+    setAccountChange(text);
+  };
+
+  const [nickNameChange, setNickNameChange] = useState("");
+  const handleNickNameChange = (text) => {
+    setNickNameChange(text);
+  };
+
+  const [emailChange, setEmailChange] = useState("");
+  const handleEmailChange = (text) => {
+    setEmailChange(text);
+  };
+
+  const [passwordChange, setPasswordChange] = useState("");
+  const handlePasswordChange = (text) => {
+    setPasswordChange(text);
+  };
+
+  const [birthChange, setBirthChange] = useState("");
+  const handleBirthChange = (text) => {
+    setBirthChange(text);
   };
 
 	return (
@@ -11,7 +65,7 @@ export default function EditMyProfileView (handleEmailChange) {
       <FlatList
         ListHeaderComponent={
           <View>
-            <View style={styles.backgroundImage}></View>
+            <View style={styles.backgroundImage}/>
             <View style={styles.profileImage}>
               <Text
                 style={{
@@ -26,7 +80,28 @@ export default function EditMyProfileView (handleEmailChange) {
             <Pressable onPress={ImgClick} style={styles.CameraImage}>
               <Image source={CameraImg} style={{width: 45,height: 45,}}/>        
             </Pressable>
-            <View style={{ marginTop: 40 }}/>
+            <View style = {{marginTop: 50, padding: 44}}>
+              <InfoInput
+                handleCheckEssentialFill={handleCheckEssentialFill}
+                handleAccountChange={handleAccountChange}
+                handleNickNameChange={handleNickNameChange}
+                handleEmailChange={handleEmailChange}
+                handlePasswordChange={handlePasswordChange}
+                handleBirthChange={handleBirthChange}
+                accountChange={accountChange}
+                nickNameChange={nickNameChange}
+                passwordChange={passwordChange}
+              />
+              <Btn
+                text={"변경확인"}
+                isFill={checkEssentialFill}
+                navigation={navigation}
+                emailChange={emailChange}
+                accountChange={accountChange}
+                nickNameChange={nickNameChange}
+                changePasswordText={passwordChange}
+              />
+            </View>
           </View>
         }
       />

--- a/front/src/profile/ProfileView.js
+++ b/front/src/profile/ProfileView.js
@@ -5,6 +5,8 @@ import {
   TouchableOpacity,
   ScrollView,
   FlatList,
+  Image,
+  Alert, 
 } from "react-native";
 import React, { useState } from "react";
 import FeedList from "./FeedList";
@@ -12,6 +14,26 @@ import { useNavigation } from "@react-navigation/core";
 
 export default function ProfileView( ) {  
   const navigation = useNavigation();
+
+  // DropDownPicker로 수정 예정
+  const BtnClick = () => {
+    Alert.alert(
+      "어느창으로 이동하시겠습니까?",
+      "",
+      [
+        {text: "취소"},
+        {
+          text: "설정창",
+          onPress: () => {navigation.navigate('SettingView')},
+        },
+        {
+          text: "신고창", 
+          onPress: () => {navigation.navigate('NotifyView')},
+        },
+      ],
+      {cancleable: false}
+    );
+  }
   
   return (
     <View style={sytles.container}>
@@ -19,7 +41,23 @@ export default function ProfileView( ) {
         ListHeaderComponent={
           <View>
             {/* <ScrollView stickyHeaderIndices={[2]}> */}
-            <View style={sytles.backgroundImage}></View>
+            <View style={sytles.backgroundImage}>
+
+              {/* DropDownPicker로 수정 예정*/}
+              <TouchableOpacity style={{
+                width: 30, 
+                marginTop: 10, 
+                marginRight: 4, 
+                alignSelf: 'flex-end'}}
+                onPress={BtnClick}
+              >
+                <Image
+                  source={require("../../assets/images/morebtn.png")}
+                  style={{ width: 30, height: 24 }}
+                />
+              </TouchableOpacity>
+
+            </View>
             <View style={sytles.profileImage}>
               <Text
                 style={{


### PR DESCRIPTION
## 개요
텍스트 인풋 그림자 사용수정
프로필 수정 뷰 수정
프로필 뷰에서 "···"버튼생성 및 alert를 통한 뷰 이동

## 변경 사항
Figma에 나와있듯이 회원가입 등에 쓰이는 텍스트 인풋에 그림자를 생성했습니다.

프로필 수정 뷰에서 각종 개인정보를 수정하는 뷰를 생성, 회원가입 부분과 동일한 코드 뷰를 사용했습니다.

프로필 뷰에서 오른쪽 위에 버튼을 생성 후 뷰 이동 기능을 넣었습니다.

## 확인 방법 (스크린샷 첨부 가능)
(그림자)
before
<img width="287" alt="shadow_B" src="https://user-images.githubusercontent.com/122427673/226088259-33dbac8c-4d45-4edc-a2c7-20e3a04dd037.png">
after
<img width="298" alt="shadow_A" src="https://user-images.githubusercontent.com/122427673/226088239-0c4b5c93-3934-47a6-bc71-b551e1f0b538.png">

(프로필 수정)
<img width="284" alt="EditProfile" src="https://user-images.githubusercontent.com/122427673/226088279-533e3c41-db21-4535-a965-0c58f6179d7b.png">

(프로필뷰 버튼)
<img width="294" alt="Setting_1" src="https://user-images.githubusercontent.com/122427673/226088285-af074fb0-fbf4-45b3-8e41-d634303a12b1.png">
<img width="288" alt="Setting_2" src="https://user-images.githubusercontent.com/122427673/226088286-d7ad8843-039b-4790-8fbd-bd5d8e2eb297.png">


## 한계점 / 문제점
프로필 뷰의 오른쪽 위 버튼은 추후 DropDownPicker를 이용해서 뷰를 선택 할 예정입니다.
프로필 수정 뷰는 회원가입과 똑같은 뷰 소스를 사용해서 추후 수정이 필요할 수 도 있습니다.