### PR TITLE
[back-end] 홈 관련 기능 추가

### DIFF
--- a/back/demo/src/main/java/OOTD/demo/diary/dto/PostDiaryDressReq.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/dto/PostDiaryDressReq.java
@@ -1,0 +1,13 @@
+package OOTD.demo.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostDiaryDressReq {
+
+    private Long dressId;
+}

--- a/back/demo/src/main/java/OOTD/demo/diary/dto/PostDiaryReq.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/dto/PostDiaryReq.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 /**
  * 게시글 엔티티 생성 관련 DTO입니다.
@@ -22,4 +23,6 @@ public class PostDiaryReq {
     private String content;
     @NotNull(message = "공개범위를 입력해주세요!")
     private PublicScope scope;
+    @NotNull(message = "옷 ID 리스트를 입력해주세요!")
+    private List<Long> dressList;
 }

--- a/back/demo/src/main/java/OOTD/demo/diary/dto/PostDiaryReq.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/dto/PostDiaryReq.java
@@ -24,5 +24,5 @@ public class PostDiaryReq {
     @NotNull(message = "공개범위를 입력해주세요!")
     private PublicScope scope;
     @NotNull(message = "옷 ID 리스트를 입력해주세요!")
-    private List<Long> dressList;
+    private List<PostDiaryDressReq> dressList;
 }

--- a/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepository.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepository.java
@@ -11,7 +11,7 @@ public interface DiaryQueryRepository {
 
     List<DiaryDto> findFollowersDiaryByUser(User user, int lastId);
     List<DiaryDto> findDiaryByDate(int lastId, int number);
-    List<HomeDiaryDto> findHomeDiaryByDate(int year, int month);
-    List<TopDiaryDto> findTopDressByDate(int year, int month);
+    List<HomeDiaryDto> findHomeDiaryByDate(User user, int year, int month);
+    List<TopDiaryDto> findTopDressByDate(User user, int year, int month);
 
 }

--- a/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepository.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepository.java
@@ -1,6 +1,8 @@
 package OOTD.demo.diary.repository;
 
 import OOTD.demo.diary.dto.DiaryDto;
+import OOTD.demo.home.dto.HomeDiaryDto;
+import OOTD.demo.home.dto.TopDiaryDto;
 import OOTD.demo.user.User;
 
 import java.util.List;
@@ -9,5 +11,7 @@ public interface DiaryQueryRepository {
 
     List<DiaryDto> findFollowersDiaryByUser(User user, int lastId);
     List<DiaryDto> findDiaryByDate(int lastId, int number);
+    List<HomeDiaryDto> findHomeDiaryByDate(int year, int month);
+    List<TopDiaryDto> findTopDressByDate(int year, int month);
 
 }

--- a/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepositoryImpl.java
@@ -7,14 +7,15 @@ import OOTD.demo.home.dto.QHomeDiaryDto;
 import OOTD.demo.home.dto.QTopDiaryDto;
 import OOTD.demo.home.dto.TopDiaryDto;
 import OOTD.demo.user.User;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import java.util.List;
 
 import static OOTD.demo.diary.QDiary.diary;
-import static OOTD.demo.dress.QDress.dress;
+import static OOTD.demo.diarydress.QDiaryDress.diaryDress;
 import static OOTD.demo.follow.QFollow.follow;
-import static com.querydsl.core.types.dsl.Wildcard.count;
 
 @RequiredArgsConstructor
 public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
@@ -50,17 +51,30 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
     }
 
     @Override
-    public List<HomeDiaryDto> findHomeDiaryByDate(int year, int month) {
+    public List<HomeDiaryDto> findHomeDiaryByDate(User user, int year, int month) {
         return queryFactory
                 .select(new QHomeDiaryDto(diary.createTime.dayOfMonth(), diary.id))
                 .from(diary)
-                .where(diary.createTime.year().eq(year).and(diary.createTime.month().eq(month)))
+                .where(diary.user.eq(user).and(diary.createTime.year().eq(year).and(diary.createTime.month().eq(month))))
+                .orderBy(diary.id.asc())
                 .fetch();
     }
 
     @Override
-    public List<TopDiaryDto> findTopDressByDate(int year, int month) {
-        return null;
+    public List<TopDiaryDto> findTopDressByDate(User user, int year, int month) {
+
+        StringPath countAlias = Expressions.stringPath("dress_count");
+
+        return queryFactory
+                .select(new QTopDiaryDto(diaryDress.dress.id, diaryDress.dress.dressName,
+                        diaryDress.dress.dressImageUrl, diaryDress.id.count().as("dress_count")))
+                .from(diary)
+                .where(diary.user.eq(user).and(diary.createTime.year().eq(year).and(diary.createTime.month().eq(month))))
+                .join(diaryDress).on(diary.id.eq(diaryDress.diary.id))
+                .groupBy(diaryDress.dress.id)
+                .orderBy(countAlias.desc())
+                .limit(5)
+                .fetch();
     }
 
 }

--- a/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/repository/DiaryQueryRepositoryImpl.java
@@ -2,13 +2,19 @@ package OOTD.demo.diary.repository;
 
 import OOTD.demo.diary.dto.DiaryDto;
 import OOTD.demo.diary.dto.QDiaryDto;
+import OOTD.demo.home.dto.HomeDiaryDto;
+import OOTD.demo.home.dto.QHomeDiaryDto;
+import OOTD.demo.home.dto.QTopDiaryDto;
+import OOTD.demo.home.dto.TopDiaryDto;
 import OOTD.demo.user.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import java.util.List;
 
 import static OOTD.demo.diary.QDiary.diary;
+import static OOTD.demo.dress.QDress.dress;
 import static OOTD.demo.follow.QFollow.follow;
+import static com.querydsl.core.types.dsl.Wildcard.count;
 
 @RequiredArgsConstructor
 public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
@@ -42,4 +48,19 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
                 .limit(number)
                 .fetch();
     }
+
+    @Override
+    public List<HomeDiaryDto> findHomeDiaryByDate(int year, int month) {
+        return queryFactory
+                .select(new QHomeDiaryDto(diary.createTime.dayOfMonth(), diary.id))
+                .from(diary)
+                .where(diary.createTime.year().eq(year).and(diary.createTime.month().eq(month)))
+                .fetch();
+    }
+
+    @Override
+    public List<TopDiaryDto> findTopDressByDate(int year, int month) {
+        return null;
+    }
+
 }

--- a/back/demo/src/main/java/OOTD/demo/diary/service/DiaryService.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/service/DiaryService.java
@@ -7,9 +7,13 @@ import OOTD.demo.comment.service.CommentService;
 import OOTD.demo.diary.Diary;
 import OOTD.demo.diary.dto.*;
 import OOTD.demo.diary.repository.DiaryRepository;
+import OOTD.demo.diarydress.DiaryDress;
+import OOTD.demo.diarydress.repository.DiaryDressRepository;
 import OOTD.demo.diaryimage.DiaryImage;
 import OOTD.demo.diaryimage.repository.DiaryImageRepository;
 import OOTD.demo.diarylike.repository.DiaryLikeRepository;
+import OOTD.demo.dress.repository.DressQueryRepository;
+import OOTD.demo.dress.repository.DressRepository;
 import OOTD.demo.file.FileUploadUtil;
 import OOTD.demo.file.dto.FileDto;
 import OOTD.demo.user.User;
@@ -22,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static OOTD.demo.diarydress.DiaryDress.createDiaryDress;
 import static OOTD.demo.diaryimage.DiaryImage.createDiaryImage;
 
 /**
@@ -37,13 +42,16 @@ public class DiaryService {
 
     private final int ONCE_PAGING_NUMBER = 20;
 
+
     private final DiaryRepository diaryRepository;
+    private final DressRepository dressRepository;
     private final FileUploadUtil fileUploadUtil;
     private final DiaryImageRepository diaryImageRepository;
     private final DiaryLikeRepository diaryLikeRepository;
     private final AuthService authService;
     private final CommentService commentService;
     private final CommentRepository commentRepository;
+    private final DiaryDressRepository diaryDressRepository;
 
     /**
      * 게시글을 생성하는 메서드입니다.
@@ -57,6 +65,11 @@ public class DiaryService {
                 authService.getCurrentLoginUser()));
 
         uploadImages(diary, files);
+
+        for (Long dressId : dto.getDressList()) {
+            diaryDressRepository.save(createDiaryDress(diary,
+                    dressRepository.findById(dressId).orElseThrow(IllegalArgumentException::new)));
+        }
 
         return new PostDiaryRes(diary.getId());
     }

--- a/back/demo/src/main/java/OOTD/demo/diary/service/DiaryService.java
+++ b/back/demo/src/main/java/OOTD/demo/diary/service/DiaryService.java
@@ -66,9 +66,9 @@ public class DiaryService {
 
         uploadImages(diary, files);
 
-        for (Long dressId : dto.getDressList()) {
+        for (PostDiaryDressReq dressReq : dto.getDressList()) {
             diaryDressRepository.save(createDiaryDress(diary,
-                    dressRepository.findById(dressId).orElseThrow(IllegalArgumentException::new)));
+                    dressRepository.findById(dressReq.getDressId()).orElseThrow(IllegalArgumentException::new)));
         }
 
         return new PostDiaryRes(diary.getId());

--- a/back/demo/src/main/java/OOTD/demo/diarydress/DiaryDress.java
+++ b/back/demo/src/main/java/OOTD/demo/diarydress/DiaryDress.java
@@ -1,0 +1,43 @@
+package OOTD.demo.diarydress;
+
+import OOTD.demo.diary.Diary;
+import OOTD.demo.dress.Dress;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiaryDress {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "diary_dress_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dress_id")
+    private Dress dress;
+
+    private DiaryDress(Diary diary, Dress dress) {
+        this.diary = diary;
+        this.dress = dress;
+    }
+
+    /**
+     * DiaryDress 엔티티를 생성하는 메서드입니다.
+     * @param diary Diary 엔티티
+     * @param dress Dress 엔티티
+     * @return 생성된 DiaryDress 엔티티
+     */
+    public static DiaryDress createDiaryDress(Diary diary, Dress dress) {
+        return new DiaryDress(diary, dress);
+    }
+}

--- a/back/demo/src/main/java/OOTD/demo/diarydress/repository/DiaryDressRepository.java
+++ b/back/demo/src/main/java/OOTD/demo/diarydress/repository/DiaryDressRepository.java
@@ -1,0 +1,8 @@
+package OOTD.demo.diarydress.repository;
+
+import OOTD.demo.diarydress.DiaryDress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryDressRepository extends JpaRepository<DiaryDress, Long> {
+
+}

--- a/back/demo/src/main/java/OOTD/demo/home/controller/HomeController.java
+++ b/back/demo/src/main/java/OOTD/demo/home/controller/HomeController.java
@@ -1,0 +1,4 @@
+package OOTD.demo.home.controller;
+
+public class HomeController {
+}

--- a/back/demo/src/main/java/OOTD/demo/home/controller/HomeController.java
+++ b/back/demo/src/main/java/OOTD/demo/home/controller/HomeController.java
@@ -1,4 +1,34 @@
 package OOTD.demo.home.controller;
 
+import OOTD.demo.common.HttpResponseUtil;
+import OOTD.demo.home.service.HomeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+@Slf4j
 public class HomeController {
+
+    private final HomeService homeService;
+    private final HttpResponseUtil httpResponseUtil;
+
+    /**
+     * 현재 사용자의 홈 캘린더를 반환하는 메서드입니다.
+     *
+     * @return 홈 캘린더 response 객체
+     */
+    @GetMapping
+    public ResponseEntity<?> getHomeCalender(@RequestParam int year, @RequestParam int month) {
+
+        return httpResponseUtil.createOkHttpResponse(homeService.getHomeCalender(year, month),
+                "홈 캘린더 반환에 성공했습니다.");
+    }
+
 }

--- a/back/demo/src/main/java/OOTD/demo/home/dto/HomeDiaryDto.java
+++ b/back/demo/src/main/java/OOTD/demo/home/dto/HomeDiaryDto.java
@@ -1,0 +1,19 @@
+package OOTD.demo.home.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HomeDiaryDto {
+
+    private Integer day;
+    private Long diaryId;
+
+    @QueryProjection
+    public HomeDiaryDto(Integer day, Long diaryId) {
+        this.day = day;
+        this.diaryId = diaryId;
+    }
+}

--- a/back/demo/src/main/java/OOTD/demo/home/dto/HomeRes.java
+++ b/back/demo/src/main/java/OOTD/demo/home/dto/HomeRes.java
@@ -12,6 +12,6 @@ import java.util.List;
 public class HomeRes {
 
     List<HomeDiaryDto> diaryDtoList;
-
+    List<TopDiaryDto> topDiaryDtoList;
 
 }

--- a/back/demo/src/main/java/OOTD/demo/home/dto/HomeRes.java
+++ b/back/demo/src/main/java/OOTD/demo/home/dto/HomeRes.java
@@ -1,0 +1,17 @@
+package OOTD.demo.home.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class HomeRes {
+
+    List<HomeDiaryDto> diaryDtoList;
+
+
+}

--- a/back/demo/src/main/java/OOTD/demo/home/dto/TopDiaryDto.java
+++ b/back/demo/src/main/java/OOTD/demo/home/dto/TopDiaryDto.java
@@ -11,12 +11,14 @@ public class TopDiaryDto {
 
     private Long id;
     private String name;
-    private int wearTimes;
+    private String imageUrl;
+    private Long wearTimes;
 
     @QueryProjection
-    public TopDiaryDto(Long id, String name, int wearTimes) {
+    public TopDiaryDto(Long id, String name, String imageUrl, Long wearTimes) {
         this.id = id;
         this.name = name;
+        this.imageUrl = imageUrl;
         this.wearTimes = wearTimes;
     }
 }

--- a/back/demo/src/main/java/OOTD/demo/home/dto/TopDiaryDto.java
+++ b/back/demo/src/main/java/OOTD/demo/home/dto/TopDiaryDto.java
@@ -1,0 +1,22 @@
+package OOTD.demo.home.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TopDiaryDto {
+
+    private Long id;
+    private String name;
+    private int wearTimes;
+
+    @QueryProjection
+    public TopDiaryDto(Long id, String name, int wearTimes) {
+        this.id = id;
+        this.name = name;
+        this.wearTimes = wearTimes;
+    }
+}

--- a/back/demo/src/main/java/OOTD/demo/home/service/HomeService.java
+++ b/back/demo/src/main/java/OOTD/demo/home/service/HomeService.java
@@ -1,5 +1,6 @@
 package OOTD.demo.home.service;
 
+import OOTD.demo.auth.service.AuthService;
 import OOTD.demo.diary.repository.DiaryRepository;
 import OOTD.demo.home.dto.HomeRes;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import javax.transaction.Transactional;
 public class HomeService {
 
     private final DiaryRepository diaryRepository;
+    private final AuthService authService;
 
     /**
      * 특정 년월을 기준으로 캘린더에 들어가는 정보를 반환합니다.
@@ -28,7 +30,9 @@ public class HomeService {
      * @return 해당 월의 캘린더 정보
      */
     public HomeRes getHomeCalender(int year, int month) {
-        return null;
+
+        return new HomeRes(diaryRepository.findHomeDiaryByDate(authService.getCurrentLoginUser(), year, month),
+                diaryRepository.findTopDressByDate(authService.getCurrentLoginUser(), year, month));
     }
 
 }

--- a/back/demo/src/main/java/OOTD/demo/home/service/HomeService.java
+++ b/back/demo/src/main/java/OOTD/demo/home/service/HomeService.java
@@ -1,0 +1,34 @@
+package OOTD.demo.home.service;
+
+import OOTD.demo.diary.repository.DiaryRepository;
+import OOTD.demo.home.dto.HomeRes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+/**
+ * Home 관련 컨트롤러입니다.
+ *
+ * @author CHO Min Ho
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class HomeService {
+
+    private final DiaryRepository diaryRepository;
+
+    /**
+     * 특정 년월을 기준으로 캘린더에 들어가는 정보를 반환합니다.
+     * @param year 년
+     * @param month 월
+     * @return 해당 월의 캘린더 정보
+     */
+    public HomeRes getHomeCalender(int year, int month) {
+        return null;
+    }
+
+}

--- a/back/demo/src/main/java/OOTD/demo/test/TestData.java
+++ b/back/demo/src/main/java/OOTD/demo/test/TestData.java
@@ -4,6 +4,8 @@ import OOTD.demo.auth.dto.CreateUserReq;
 import OOTD.demo.auth.service.AuthService;
 import OOTD.demo.diary.Diary;
 import OOTD.demo.diary.repository.DiaryRepository;
+import OOTD.demo.diarydress.DiaryDress;
+import OOTD.demo.diarydress.repository.DiaryDressRepository;
 import OOTD.demo.diaryimage.repository.DiaryImageRepository;
 import OOTD.demo.dress.Dress;
 import OOTD.demo.dress.repository.DressHashTagRepository;
@@ -21,6 +23,7 @@ import java.time.LocalDate;
 
 import static OOTD.demo.diary.Diary.createPost;
 import static OOTD.demo.diary.PublicScope.ALL;
+import static OOTD.demo.diarydress.DiaryDress.createDiaryDress;
 import static OOTD.demo.diaryimage.DiaryImage.createDiaryImage;
 import static OOTD.demo.dress.Dress.createDress;
 import static OOTD.demo.dress.DressHashTag.createDressHashTag;
@@ -56,6 +59,7 @@ public class TestData {
         private final DressRepository dressRepository;
         private final HashTagRepository hashTagRepository;
         private final DressHashTagRepository dressHashTagRepository;
+        private final DiaryDressRepository diaryDressRepository;
 
         @Transactional
         public void init() {
@@ -81,6 +85,17 @@ public class TestData {
             // 2. Diary Test Data 삽입
             Diary diary1 = diaryRepository.save(createPost("게시글 제목1", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
                     ALL, user1));
+            Diary diary1_2 = diaryRepository.save(createPost("게시글 제목1222", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
+                    ALL, user1));
+            Diary diary1_3 = diaryRepository.save(createPost("게시글 제목1333", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
+                    ALL, user1));
+            Diary diary1_4 = diaryRepository.save(createPost("게시글 제목1444", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
+                    ALL, user1));
+            Diary diary1_5 = diaryRepository.save(createPost("게시글 제목1555", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
+                    ALL, user1));
+            Diary diary1_6 = diaryRepository.save(createPost("게시글 제목1666", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
+                    ALL, user1));
+
             Diary diary2 = diaryRepository.save(createPost("게시글 제목2", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
                     ALL, user2));
             Diary diary3 = diaryRepository.save(createPost("게시글 제목3", "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.",
@@ -131,6 +146,16 @@ public class TestData {
             // 4. Dress Test Data 삽입
             Dress dress1 = dressRepository.save(createDress(user1, "아우터1", OUTER,
                     "https://ootd-s3-bucket.s3.ap-northeast-2.amazonaws.com/diary/_test3_1674024697809.jpg"));
+            Dress dress1_2 = dressRepository.save(createDress(user1, "아우터1_2", OUTER,
+                    "https://ootd-s3-bucket.s3.ap-northeast-2.amazonaws.com/diary/_test3_1674024697809.jpg"));
+            Dress dress1_3 = dressRepository.save(createDress(user1, "아우터1_3", OUTER,
+                    "https://ootd-s3-bucket.s3.ap-northeast-2.amazonaws.com/diary/_test3_1674024697809.jpg"));
+            Dress dress1_4 = dressRepository.save(createDress(user1, "아우터1_4", OUTER,
+                    "https://ootd-s3-bucket.s3.ap-northeast-2.amazonaws.com/diary/_test3_1674024697809.jpg"));
+            Dress dress1_5 = dressRepository.save(createDress(user1, "아우터1_5", OUTER,
+                    "https://ootd-s3-bucket.s3.ap-northeast-2.amazonaws.com/diary/_test3_1674024697809.jpg"));
+
+
             Dress dress2 = dressRepository.save(createDress(user2, "아우터1", OUTER,
                     "https://ootd-s3-bucket.s3.ap-northeast-2.amazonaws.com/diary/_test3_1674024697809.jpg"));
             Dress dress3 = dressRepository.save(createDress(user3, "아우터1", OUTER,
@@ -161,6 +186,28 @@ public class TestData {
             dressHashTagRepository.save(createDressHashTag(dress3, tag1));
             dressHashTagRepository.save(createDressHashTag(dress4, tag1));
             dressHashTagRepository.save(createDressHashTag(dress5, tag1));
+
+
+            // 7. DiaryDress 삽입
+            diaryDressRepository.save(createDiaryDress(diary1, dress1));
+            diaryDressRepository.save(createDiaryDress(diary1, dress1_2));
+            diaryDressRepository.save(createDiaryDress(diary1, dress1_3));
+
+            diaryDressRepository.save(createDiaryDress(diary1_2, dress1));
+            diaryDressRepository.save(createDiaryDress(diary1_3, dress1));
+            diaryDressRepository.save(createDiaryDress(diary1_4, dress1));
+            diaryDressRepository.save(createDiaryDress(diary1_5, dress1));
+            diaryDressRepository.save(createDiaryDress(diary1_6, dress1));
+
+            diaryDressRepository.save(createDiaryDress(diary1_2, dress1));
+            diaryDressRepository.save(createDiaryDress(diary1_3, dress1_2));
+            diaryDressRepository.save(createDiaryDress(diary1_4, dress1_3));
+
+            diaryDressRepository.save(createDiaryDress(diary1_2, dress1_5));
+            diaryDressRepository.save(createDiaryDress(diary1_3, dress1_4));
+            diaryDressRepository.save(createDiaryDress(diary1_4, dress1_4));
+            diaryDressRepository.save(createDiaryDress(diary1_5, dress1_3));
+
 
         }
     }


### PR DESCRIPTION
## 개요
1. 홈 캘린더 관련 기능 추가

## 변경 사항
1. 게시글 생성 시 Dress 엔티티와 조합해서 생성하도록 API 변경
2. 캘린더 내부 특정 년월에 작성된 게시글 조회 API 추가
3. 캘린더 내부 특정 년월에 가장 많은 Dress Top 5 API 추가 (2와 동일한 API)

## 확인 방법 (스크린샷 첨부 가능)

## 한계점 / 문제점
1. 전월 대비 몇번을 더 입었는지 기능 (캘린더 내부) 미완성